### PR TITLE
Ruler, time-aware SegmentMap and loop editing

### DIFF
--- a/mamar-web/src/app/App.tsx
+++ b/mamar-web/src/app/App.tsx
@@ -30,7 +30,7 @@ export function RomDataConsumer() {
             <div className={styles.playbackControlsContainer}>
                 <PlaybackControls />
             </div>
-            <View gridArea="content" overflow="auto">
+            <View gridArea="content">
                 <Main />
             </View>
         </Grid>

--- a/mamar-web/src/app/doc/ActiveDoc.module.scss
+++ b/mamar-web/src/app/doc/ActiveDoc.module.scss
@@ -2,5 +2,4 @@
     height: calc(100vh - 36px - 38px);
     overflow: hidden;
     display: grid;
-    grid-template-rows: 1fr auto; /* SegmentMap fits, panel grows */
 }

--- a/mamar-web/src/app/doc/ActiveDoc.module.scss
+++ b/mamar-web/src/app/doc/ActiveDoc.module.scss
@@ -1,5 +1,6 @@
 .container {
-    height: 100%;
+    height: calc(100vh - 36px - 38px);
     overflow: hidden;
     display: grid;
+    grid-template-rows: 1fr auto; /* SegmentMap fits, panel grows */
 }

--- a/mamar-web/src/app/doc/ActiveDoc.tsx
+++ b/mamar-web/src/app/doc/ActiveDoc.tsx
@@ -78,11 +78,10 @@ export default function ActiveDoc() {
                         {...provided.droppableProps}
                         className={styles.container}
                         style={{
-                            gridTemplateRows: doc.panelContent.type === "not_open" ? "100%" : "50% 50%",
                             overflow: "hidden",
                         }}
                     >
-                        <View overflow="overlay">
+                        <View overflow="overlay" UNSAFE_style={{ minHeight: 0 }}>
                             <SegmentMap />
                             {provided.placeholder}
                         </View>

--- a/mamar-web/src/app/doc/ActiveDoc.tsx
+++ b/mamar-web/src/app/doc/ActiveDoc.tsx
@@ -78,6 +78,7 @@ export default function ActiveDoc() {
                         {...provided.droppableProps}
                         className={styles.container}
                         style={{
+                            gridTemplateRows: doc.panelContent.type === "not_open" ? "100%" : "50% 50%",
                             overflow: "hidden",
                         }}
                     >

--- a/mamar-web/src/app/doc/Ruler.module.scss
+++ b/mamar-web/src/app/doc/Ruler.module.scss
@@ -1,0 +1,92 @@
+$ruler-height: 22px;
+$trackHead-width: 8em;
+
+.ruler {
+    display: flex;
+    width: max-content;
+    height: $ruler-height;
+
+    margin-left: $trackHead-width;
+
+    --ticks-per-beat: 48px;
+    --color: var(--spectrum-global-color-gray-400);
+    background-color: var(--spectrum-global-color-gray-200);
+    background-image: repeating-linear-gradient(to right, var(--color) 0, var(--color) 1px, transparent 1px, transparent calc(var(--ticks-per-beat) / var(--ruler-zoom)));
+    background-size: calc(var(--ticks-per-beat) / var(--ruler-zoom)) 50%;
+    background-repeat: repeat no-repeat;
+    background-position-y: calc(var(--ticks-per-beat) / 4);
+
+    position: sticky;
+    top: 0;
+
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+
+    /* Hide ruler above where trackHeads are when scrolling */
+    &::after {
+        content: "";
+        position: fixed;
+        left: 0;
+        width: $trackHead-width;
+        height: $ruler-height;
+        background: var(--spectrum-global-color-gray-100);
+    }
+}
+
+.rulerSegment {
+    display: flex;
+    color: var(--spectrum-global-color-gray-800);
+}
+
+.loop {
+    background: var(--yellow);
+    color: var(--spectrum-global-color-gray-200);
+
+    /* Need to repeat .ruler background-image here since we overlaid it with a yellow background */
+    --color: rgba(0, 0, 0, 0.3);
+    background-image: repeating-linear-gradient(to right, var(--color) 0, var(--color) 1px, transparent 1px, transparent calc(var(--ticks-per-beat) / var(--ruler-zoom)));
+    background-size: calc(var(--ticks-per-beat) / var(--ruler-zoom)) 50%;
+    background-repeat: repeat no-repeat;
+    background-position-y: calc(var(--ticks-per-beat) / 4);
+
+    &.highlighted {
+        filter: brightness(1.2);
+    }
+}
+
+.relative {
+    position: relative;
+}
+
+.loopHandle {
+    position: absolute;
+    width: 16px;
+    transform: translateX(-50%);
+    height: 100%;
+
+    pointer-events: auto;
+
+    z-index: 1;
+
+    &[data-kind=start] {
+        cursor: w-resize;
+    }
+
+    &[data-kind=end] {
+        cursor: e-resize;
+    }
+
+    &.active {
+        position: fixed;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        transform: none;
+        z-index: 9999;
+    }
+}
+
+.bar {
+    padding-left: calc(8px / var(--ruler-zoom));
+    border-left: var(--color) 1px solid; /* Extend the background-image */
+    flex: none;
+}

--- a/mamar-web/src/app/doc/Ruler.module.scss
+++ b/mamar-web/src/app/doc/Ruler.module.scss
@@ -63,6 +63,8 @@ $trackHead-width: 100px;
 .loopIterCount {
     color: var(--spectrum-global-color-gray-200);
     margin-right: 4px;
+    font-weight: 600;
+    font-size: 0.9em;
 }
 
 .relative {

--- a/mamar-web/src/app/doc/Ruler.module.scss
+++ b/mamar-web/src/app/doc/Ruler.module.scss
@@ -1,20 +1,18 @@
-$ruler-height: 22px;
+$ruler-height: 36px;
 $trackHead-width: 100px;
 
 .ruler {
     display: flex;
+    flex-direction: column;
+
     width: max-content;
     height: $ruler-height;
 
     margin-left: $trackHead-width;
 
     --ticks-per-beat: 48px;
-    --color: var(--spectrum-global-color-gray-400);
+
     background-color: var(--spectrum-global-color-gray-200);
-    background-image: repeating-linear-gradient(to right, var(--color) 0, var(--color) 1px, transparent 1px, transparent calc(var(--ticks-per-beat) / var(--ruler-zoom)));
-    background-size: calc(var(--ticks-per-beat) / var(--ruler-zoom)) 50%;
-    background-repeat: repeat no-repeat;
-    background-position-y: calc(var(--ticks-per-beat) / 4);
 
     position: sticky;
     top: 0;
@@ -35,22 +33,36 @@ $trackHead-width: 100px;
 .rulerSegment {
     display: flex;
     color: var(--spectrum-global-color-gray-800);
+
+    cursor: pointer;
+
+    border-left: 1px dashed var(--spectrum-global-color-gray-400);
+}
+
+.loops {
+    display: flex;
+    height: $ruler-height - 22px;
 }
 
 .loop {
-    background: var(--yellow);
-    color: var(--spectrum-global-color-gray-200);
+    background-color: var(--yellow);
 
-    /* Need to repeat .ruler background-image here since we overlaid it with a yellow background */
-    --color: rgba(0, 0, 0, 0.3);
-    background-image: repeating-linear-gradient(to right, var(--color) 0, var(--color) 1px, transparent 1px, transparent calc(var(--ticks-per-beat) / var(--ruler-zoom)));
-    background-size: calc(var(--ticks-per-beat) / var(--ruler-zoom)) 50%;
-    background-repeat: repeat no-repeat;
-    background-position-y: calc(var(--ticks-per-beat) / 4);
+    border-radius: 6px;
 
     &.highlighted {
         filter: brightness(1.2);
     }
+
+    width: 100%;
+
+    display: flex;
+    align-items: center;
+    justify-content: end;
+}
+
+.loopIterCount {
+    color: var(--spectrum-global-color-gray-200);
+    margin-right: 4px;
 }
 
 .relative {
@@ -83,6 +95,20 @@ $trackHead-width: 100px;
         transform: none;
         z-index: 9999;
     }
+}
+
+.bars {
+    display: flex;
+
+    --color: var(--spectrum-global-color-gray-400);
+    background-image: repeating-linear-gradient(to right, var(--color) 0, var(--color) 1px, transparent 1px, transparent calc(var(--ticks-per-beat) / var(--ruler-zoom)));
+    background-size: calc(var(--ticks-per-beat) / var(--ruler-zoom)) 50%;
+    background-repeat: repeat no-repeat;
+    background-position-y: calc(var(--ticks-per-beat) / 4);
+
+    color: var(--spectrum-global-color-gray-700);
+
+    pointer-events: none;
 }
 
 .bar {

--- a/mamar-web/src/app/doc/Ruler.module.scss
+++ b/mamar-web/src/app/doc/Ruler.module.scss
@@ -1,5 +1,5 @@
 $ruler-height: 22px;
-$trackHead-width: 8em;
+$trackHead-width: 100px;
 
 .ruler {
     display: flex;

--- a/mamar-web/src/app/doc/Ruler.tsx
+++ b/mamar-web/src/app/doc/Ruler.tsx
@@ -1,0 +1,153 @@
+import classNames from "classnames"
+import { Segment } from "pm64-typegen"
+import { useState } from "react"
+
+import styles from "./Ruler.module.scss"
+
+import { useBgm, useVariation } from "../store"
+
+interface Loop {
+    id: number
+    start: number
+    end: number
+}
+
+function getLoops(segments: Segment[]): Loop[] {
+    const loops = []
+
+    for (let startIdx = 0; startIdx < segments.length; startIdx++) {
+        const start = segments[startIdx]
+        if (start.type === "StartLoop") {
+            // Look for EndLoop
+            for (let endIdx = 0; endIdx < segments.length; endIdx++) {
+                const end = segments[endIdx]
+                if (end.type === "EndLoop" && end.label_index === start.label_index) {
+                    loops.push({
+                        id: start.id,
+                        start: startIdx,
+                        end: endIdx,
+                    })
+                    break
+                }
+            }
+        }
+    }
+
+    return loops
+}
+
+function LoopHandle({ segment, kind, loop, setHighlightedLoop }: {
+    segment: number
+    kind: "start" | "end"
+    loop: Loop
+    setHighlightedLoop: (id: Loop["id"] | null) => void
+}) {
+    const [active, setActive] = useState(true)
+    return <div className={styles.relative}>
+        <div
+            className={classNames({
+                [styles.loopHandle]: true,
+                [styles.active]: active,
+            })}
+            data-kind={kind}
+            title={`Drag to move ${kind} of loop`}
+            onMouseDown={() => {
+                setHighlightedLoop(loop.id)
+                setActive(true)
+            }}
+            onMouseUp={() => {
+                // TODO: dispatch a segment move to the new location
+                setHighlightedLoop(null)
+                setActive(false)
+            }}
+        >
+        </div>
+    </div>
+}
+
+export function ticksToStyle(ticks: number) {
+    return {
+        width: `calc(${ticks}px / var(--ruler-zoom))`,
+    }
+}
+
+// TODO: cache this better
+export function useSegmentLengths(): number[] {
+    const [bgm] = useBgm()
+    const [variation] = useVariation()
+    const segments = variation?.segments ?? []
+
+    return segments.map(segment => {
+        if (bgm && segment.type === "Subseg") {
+            const master = bgm.trackLists[segment.trackList].tracks[0]
+            return master.commands.vec.reduce((totalDelay, event) => {
+                if (event.type === "Delay") {
+                    return totalDelay + event.value
+                } else {
+                    return totalDelay
+                }
+            }, 0)
+        } else {
+            return 0
+        }
+    })
+}
+
+// TODO: bar counts where a segment is not a full bar
+export default function Ruler({ segments }: { segments: Segment[] }) {
+    const loops = getLoops(segments)
+    const segmentLengths = useSegmentLengths()
+    const [highlightedLoop, setHighlightedLoop] = useState<Loop["id"] | null>(null)
+
+    const TICKS_PER_BEAT = 48
+    const BEATS_PER_BAR = 4 // TODO: read time signature from midi
+
+    const elements = []
+    let time = 0
+    let currentLoop: Loop | null = null
+    for (let segment = 0; segment < segmentLengths.length; segment++) {
+        const length = segmentLengths[segment]
+
+        if (length === 0) {
+            // Loop or other, so check for loop handle
+            for (const loop of loops) {
+                if (segment === loop.start) {
+                    currentLoop = loop
+                    elements.push(<LoopHandle segment={segment} kind="start" loop={loop} setHighlightedLoop={setHighlightedLoop} />)
+                }
+                if (segment === loop.end) {
+                    currentLoop = null
+                    elements.push(<LoopHandle segment={segment} kind="end" loop={loop} setHighlightedLoop={setHighlightedLoop} />)
+                }
+                continue
+            }
+            continue
+        }
+
+        const barLength = length / (TICKS_PER_BEAT * BEATS_PER_BAR)
+        const bars = []
+        for (let i = 0; i < barLength; i++) {
+            const bar = Math.floor(time / (TICKS_PER_BEAT * BEATS_PER_BAR)) + i
+            bars.push(<div className={styles.bar} style={ticksToStyle(TICKS_PER_BEAT * BEATS_PER_BAR)}>
+                {bar}
+            </div>)
+        }
+
+        elements.push(<div
+            className={classNames({
+                [styles.rulerSegment]: true,
+                [styles.loop]: currentLoop !== null,
+                [styles.highlighted]: currentLoop !== null && (currentLoop.id === highlightedLoop),
+            })}
+            style={ticksToStyle(length)}
+        >
+            {bars}
+        </div>)
+
+        time += length
+    }
+
+    return <div className={styles.ruler}>
+        {elements}
+    </div>
+}

--- a/mamar-web/src/app/doc/Ruler.tsx
+++ b/mamar-web/src/app/doc/Ruler.tsx
@@ -68,15 +68,12 @@ function LoopHandle({ segment, kind, loop, setHighlightedLoop }: {
                 let closestDistance = targetTime
                 segmentLengths.forEach((length, index) => {
                     curTime += length
-                    console.log(index, length)
                     const distance = Math.abs(curTime - targetTime)
                     if (distance < closestDistance) {
                         closestDistance = distance
                         closestIndex = index
                     }
                 })
-
-                console.log({ targetTime, closestIndex, closestDistance })
 
                 if (closestDistance < 50) {
                     dispatch({
@@ -122,7 +119,10 @@ export function useSegmentLengths(): number[] {
 }
 
 // TODO: bar counts where a segment is not a full bar
-export default function Ruler({ segments }: { segments: Segment[] }) {
+export default function Ruler() {
+    const [variation, dispatch] = useVariation()
+    const segments = variation?.segments ?? []
+
     const loops = getLoops(segments)
     const segmentLengths = useSegmentLengths()
     const [highlightedLoop, setHighlightedLoop] = useState<Loop["id"] | null>(null)
@@ -142,11 +142,11 @@ export default function Ruler({ segments }: { segments: Segment[] }) {
             for (const loop of loops) {
                 if (i === loop.start) {
                     currentLoop = loop
-                    elements.push(<LoopHandle key={loop.id} segment={segment.id} kind="start" loop={loop} setHighlightedLoop={setHighlightedLoop} />)
+                    elements.push(<LoopHandle key={`start_loop_${loop.id}`} segment={segment.id} kind="start" loop={loop} setHighlightedLoop={setHighlightedLoop} />)
                 }
                 if (i === loop.end) {
                     currentLoop = null
-                    elements.push(<LoopHandle key={loop.id} segment={segment.id} kind="end" loop={loop} setHighlightedLoop={setHighlightedLoop} />)
+                    elements.push(<LoopHandle key={`end_loop_${loop.id}`} segment={segment.id} kind="end" loop={loop} setHighlightedLoop={setHighlightedLoop} />)
                 }
                 continue
             }
@@ -163,12 +163,19 @@ export default function Ruler({ segments }: { segments: Segment[] }) {
         }
 
         elements.push(<div
+            key={segment.id}
             className={classNames({
                 [styles.rulerSegment]: true,
                 [styles.loop]: currentLoop !== null,
                 [styles.highlighted]: currentLoop !== null && (currentLoop.id === highlightedLoop),
             })}
             style={ticksToStyle(length)}
+            onDoubleClick={() => {
+                dispatch({
+                    type: "toggle_segment_loop",
+                    id: segment.id,
+                })
+            }}
         >
             {bars}
         </div>)

--- a/mamar-web/src/app/doc/Ruler.tsx
+++ b/mamar-web/src/app/doc/Ruler.tsx
@@ -1,11 +1,11 @@
-import { Button, ButtonGroup, Content, Dialog, DialogTrigger, Divider, Footer, Form, Heading, NumberField, Switch } from "@adobe/react-spectrum"
+import { Button, ButtonGroup, Content, Dialog, DialogTrigger, Divider, Form, Heading, NumberField, Switch } from "@adobe/react-spectrum"
 import classNames from "classnames"
 import { Segment } from "pm64-typegen"
 import { useState } from "react"
 import { usePress } from "react-aria"
 
 import styles from "./Ruler.module.scss"
-import { useTime } from "./SegmentMap"
+import { useTime } from "./timectx"
 
 import { useBgm, useSegment, useVariation } from "../store"
 
@@ -122,9 +122,8 @@ export function useSegmentLengths(): number[] {
     })
 }
 
-// TODO: bar counts where a segment is not a full bar
 export default function Ruler() {
-    const [variation, dispatch] = useVariation()
+    const [variation] = useVariation()
     const segments = variation?.segments ?? []
 
     const loops = getLoops(segments)

--- a/mamar-web/src/app/doc/Ruler.tsx
+++ b/mamar-web/src/app/doc/Ruler.tsx
@@ -42,7 +42,7 @@ function LoopHandle({ segment, kind, loop, setHighlightedLoop }: {
     loop: Loop
     setHighlightedLoop: (id: Loop["id"] | null) => void
 }) {
-    const [active, setActive] = useState(true)
+    const [active, setActive] = useState(false)
     return <div className={styles.relative}>
         <div
             className={classNames({

--- a/mamar-web/src/app/doc/SegmentMap.module.scss
+++ b/mamar-web/src/app/doc/SegmentMap.module.scss
@@ -1,6 +1,5 @@
 $trackHeight: 70px;
 $trackHead-width: 8em;
-$ruler-height: 22px;
 
 .table {
     width: 100%;
@@ -8,60 +7,6 @@ $ruler-height: 22px;
     user-select: none;
 
     --ruler-zoom: 2;
-}
-
-.ruler {
-    display: flex;
-    width: max-content;
-    height: $ruler-height;
-
-    margin-left: $trackHead-width;
-
-    --ticks-per-beat: 48px;
-    --color: var(--spectrum-global-color-gray-400);
-    background-color: var(--spectrum-global-color-gray-200);
-    background-image: repeating-linear-gradient(to right, var(--color) 0, var(--color) 1px, transparent 1px, transparent calc(var(--ticks-per-beat) / var(--ruler-zoom)));
-    background-size: calc(var(--ticks-per-beat) / var(--ruler-zoom)) 50%;
-    background-repeat: repeat no-repeat;
-    background-position-y: calc(var(--ticks-per-beat) / 4);
-
-    position: sticky;
-    top: 0;
-
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-
-    /* Hide ruler above where trackHeads are when scrolling */
-    &::after {
-        content: "";
-        position: fixed;
-        left: 0;
-        width: $trackHead-width;
-        height: $ruler-height;
-        background: var(--spectrum-global-color-gray-100);
-    }
-}
-
-.rulerSegment {
-    display: flex;
-    color: var(--spectrum-global-color-gray-800);
-}
-
-.loop {
-    background: var(--yellow);
-    color: var(--spectrum-global-color-gray-200);
-
-    /* Need to repeat .ruler background-image here since we overlaid it with a yellow background */
-    --color: rgba(0, 0, 0, 0.3);
-    background-image: repeating-linear-gradient(to right, var(--color) 0, var(--color) 1px, transparent 1px, transparent calc(var(--ticks-per-beat) / var(--ruler-zoom)));
-    background-size: calc(var(--ticks-per-beat) / var(--ruler-zoom)) 50%;
-    background-repeat: repeat no-repeat;
-    background-position-y: calc(var(--ticks-per-beat) / 4);
-}
-
-.bar {
-    padding-left: calc(8px / var(--ruler-zoom));
-    border-left: var(--color) 1px solid; /* Extend the background-image */
-    flex: none;
 }
 
 .track {

--- a/mamar-web/src/app/doc/SegmentMap.module.scss
+++ b/mamar-web/src/app/doc/SegmentMap.module.scss
@@ -1,5 +1,5 @@
 $trackHeight: 70px;
-$trackHead-width: 8em;
+$trackHead-width: 100px; // Match with TRACK_HEAD_WIDTH
 
 .table {
     width: 100%;
@@ -7,6 +7,7 @@ $trackHead-width: 8em;
     user-select: none;
 
     --ruler-zoom: 2;
+    --trackHead-width: $trackHead-width;
 }
 
 .track {

--- a/mamar-web/src/app/doc/SegmentMap.module.scss
+++ b/mamar-web/src/app/doc/SegmentMap.module.scss
@@ -1,8 +1,6 @@
 $trackHeight: 70px;
 
 .table {
-    border-collapse: collapse;
-
     width: 100%;
 
     user-select: none;
@@ -22,7 +20,14 @@ $trackHeight: 70px;
     }
 }
 
+.ruler {
+    display: flex;
+    width: max-content;
+}
+
 .track {
+    display: flex;
+    width: max-content;
     height: $trackHeight;
 
     &:nth-child(even) {

--- a/mamar-web/src/app/doc/SegmentMap.module.scss
+++ b/mamar-web/src/app/doc/SegmentMap.module.scss
@@ -1,28 +1,67 @@
 $trackHeight: 70px;
+$trackHead-width: 8em;
+$ruler-height: 22px;
 
 .table {
     width: 100%;
 
     user-select: none;
 
-    /*tr {
-        &:not(:first-child) {
-            background: var(--spectrum-global-color-gray-100);
-        }
-
-        &:nth-child(even) {
-            background: var(--spectrum-global-color-gray-75);
-        }
-    }*/
-
-    td {
-        padding: 0;
-    }
+    --ruler-zoom: 2;
 }
 
 .ruler {
     display: flex;
     width: max-content;
+    height: $ruler-height;
+
+    margin-left: $trackHead-width;
+
+    --ticks-per-beat: 48px;
+    --color: var(--spectrum-global-color-gray-400);
+    background-color: var(--spectrum-global-color-gray-200);
+    background-image: repeating-linear-gradient(to right, var(--color) 0, var(--color) 1px, transparent 1px, transparent calc(var(--ticks-per-beat) / var(--ruler-zoom)));
+    background-size: calc(var(--ticks-per-beat) / var(--ruler-zoom)) 50%;
+    background-repeat: repeat no-repeat;
+    background-position-y: calc(var(--ticks-per-beat) / 4);
+
+    position: sticky;
+    top: 0;
+
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+
+    /* Hide ruler above where trackHeads are when scrolling */
+    &::after {
+        content: "";
+        position: fixed;
+        left: 0;
+        width: $trackHead-width;
+        height: $ruler-height;
+        background: var(--spectrum-global-color-gray-100);
+    }
+}
+
+.rulerSegment {
+    display: flex;
+    color: var(--spectrum-global-color-gray-800);
+}
+
+.loop {
+    background: var(--yellow);
+    color: var(--spectrum-global-color-gray-200);
+
+    /* Need to repeat .ruler background-image here since we overlaid it with a yellow background */
+    --color: rgba(0, 0, 0, 0.3);
+    background-image: repeating-linear-gradient(to right, var(--color) 0, var(--color) 1px, transparent 1px, transparent calc(var(--ticks-per-beat) / var(--ruler-zoom)));
+    background-size: calc(var(--ticks-per-beat) / var(--ruler-zoom)) 50%;
+    background-repeat: repeat no-repeat;
+    background-position-y: calc(var(--ticks-per-beat) / 4);
+}
+
+.bar {
+    padding-left: calc(8px / var(--ruler-zoom));
+    border-left: var(--color) 1px solid; /* Extend the background-image */
+    flex: none;
 }
 
 .track {
@@ -35,25 +74,22 @@ $trackHeight: 70px;
     }
 }
 
-td.trackHead {
-    width: 8em;
+.trackHead {
+    width: $trackHead-width;
     border-right: 1px solid var(--spectrum-global-color-gray-100);
 
     padding: 4px 16px;
     height: 100%;
 
+    position: sticky;
+    left: 0;
+
+    background: var(--spectrum-global-color-gray-100);
+
     .trackName {
         color: var(--spectrum-global-color-gray-900);
         margin-bottom: 4px;
     }
-}
-
-td.loop {
-    color: black;
-    background: var(--yellow);
-    font-weight: 600;
-
-    padding: 0 4px;
 }
 
 .pianoRollThumbnail {

--- a/mamar-web/src/app/doc/SegmentMap.tsx
+++ b/mamar-web/src/app/doc/SegmentMap.tsx
@@ -1,30 +1,15 @@
 import classNames from "classnames"
-import { useId, useRef, createContext, useContext } from "react"
+import { useId, useRef } from "react"
 
 import Ruler, { ticksToStyle, useSegmentLengths } from "./Ruler"
 import styles from "./SegmentMap.module.scss"
+import { TimeProvider } from "./timectx"
 
 import TrackControls from "../emu/TrackControls"
 import { useBgm, useDoc, useVariation } from "../store"
 import useSelection, { SelectionProvider } from "../util/hooks/useSelection"
 
 const TRACK_HEAD_WIDTH = 100 // Match with $trackHead-width
-
-interface Time {
-    xToTicks: (clientX: number) => number
-}
-
-const TIME_CTX = createContext<Time | null>(null)
-
-export function useTime(): Time {
-    const time = useContext(TIME_CTX)
-
-    if (!time) {
-        throw new Error("TimeProvider missing in tree")
-    }
-
-    return time
-}
 
 function PianoRollThumbnail({ trackIndex, trackListIndex }: { trackIndex: number, trackListIndex: number }) {
     const [doc, dispatch] = useDoc()
@@ -79,7 +64,7 @@ function Container() {
 
     const tracks = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] // TODO: don't show track 0
 
-    return <TIME_CTX.Provider value={{
+    return <TimeProvider value={{
         xToTicks(clientX: number): number {
             if (!container.current) return NaN
             const px = clientX - container.current.getBoundingClientRect().left
@@ -118,7 +103,7 @@ function Container() {
                 </div>)}
             </div>}
         </div>
-    </TIME_CTX.Provider>
+    </TimeProvider>
 }
 
 export default function SegmentMap() {

--- a/mamar-web/src/app/doc/SegmentMap.tsx
+++ b/mamar-web/src/app/doc/SegmentMap.tsx
@@ -97,7 +97,7 @@ function Container() {
             }}
         >
             {variation && <div>
-                <Ruler segments={variation.segments} />
+                <Ruler />
                 {tracks.map(i => <div key={i} className={styles.track} aria-label={`Track ${i}`}>
                     {<div className={styles.trackHead}>
                         <div className={styles.trackName}>Track {i}</div>

--- a/mamar-web/src/app/doc/SegmentMap.tsx
+++ b/mamar-web/src/app/doc/SegmentMap.tsx
@@ -77,7 +77,7 @@ function Container() {
     const segmentLengths = useSegmentLengths()
     const container = useRef<HTMLDivElement | null>(null)
 
-    const tracks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] // note: no master track
+    const tracks = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] // TODO: don't show track 0
 
     return <TIME_CTX.Provider value={{
         xToTicks(clientX: number): number {
@@ -100,8 +100,8 @@ function Container() {
                 <Ruler />
                 {tracks.map(i => <div key={i} className={styles.track} aria-label={`Track ${i}`}>
                     {<div className={styles.trackHead}>
-                        <div className={styles.trackName}>Track {i}</div>
-                        <TrackControls trackIndex={i} />
+                        <div className={styles.trackName}>{i === 0 ? "Master" : `Track ${i}`}</div>
+                        {i > 0 && <TrackControls trackIndex={i} />}
                     </div>}
                     {variation.segments.map((segment, segmentIndex) => {
                         if (segment.type === "Subseg") {

--- a/mamar-web/src/app/doc/timectx.ts
+++ b/mamar-web/src/app/doc/timectx.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react"
+
+export interface Time {
+    xToTicks: (clientX: number) => number
+}
+
+const TIME_CTX = createContext<Time | null>(null)
+
+export function useTime(): Time {
+    const time = useContext(TIME_CTX)
+
+    if (!time) {
+        throw new Error("TimeProvider missing in tree")
+    }
+
+    return time
+}
+
+export const TimeProvider = TIME_CTX.Provider

--- a/mamar-web/src/app/header/SponsorButton.tsx
+++ b/mamar-web/src/app/header/SponsorButton.tsx
@@ -4,7 +4,7 @@ import styles from "./SponsorButton.module.scss"
 
 export default function SponsorButton() {
     return <a
-        href="https://github.com/sponsors/nanaian"
+        href="https://github.com/sponsors/bates64"
         target="_blank"
         rel="noopener noreferrer"
         className={styles.button}

--- a/mamar-web/src/app/store/variation.ts
+++ b/mamar-web/src/app/store/variation.ts
@@ -1,8 +1,42 @@
+import produce from "immer"
 import { Segment, Variation } from "pm64-typegen"
 
 import { useBgm } from "./bgm"
 import { useDoc } from "./doc"
 import { SegmentAction, segmentReducer } from "./segment"
+
+function cleanLoops(segments: (Segment | null)[]): Segment[] {
+    return produce(segments, cleaned => {
+        // Ensure StartLoop comes before EndLoop with the same label_index
+        for (let i = 0; i < cleaned.length; i++) {
+            const endLoop = cleaned[i]
+            if (endLoop?.type === "EndLoop") {
+                for (let j = i + 1; j < cleaned.length; j++) {
+                    const startLoop = cleaned[j]
+                    if (startLoop?.type === "StartLoop" && startLoop.label_index === endLoop.label_index) {
+                        const temp = cleaned[i]
+                        cleaned[i] = cleaned[j]
+                        cleaned[j] = temp
+                        break
+                    }
+                }
+            }
+        }
+
+        // Remove adjacent StartLoop and EndLoop with matching label_index
+        for (let i = 0; i < cleaned.length - 1; i++) {
+            const a = cleaned[i]
+            const b = cleaned[i + 1]
+            if (a?.type === "StartLoop" &&
+                b?.type === "EndLoop" &&
+                a.label_index === b.label_index
+            ) {
+                cleaned[i] = null
+                cleaned[i + 1] = null
+            }
+        }
+    }).filter(s => s !== null)
+}
 
 export type VariationAction = {
     type: "segment"
@@ -17,9 +51,8 @@ export type VariationAction = {
     id: number
     trackList: number
 } | {
-    type: "add_loop_start"
+    type: "toggle_segment_loop"
     id: number
-    iterCount: number
 }
 
 export function variationReducer(variation: Variation, action: VariationAction): Variation {
@@ -36,51 +69,16 @@ export function variationReducer(variation: Variation, action: VariationAction):
             }),
         }
     case "move_segment":
-        const fromIndex = variation.segments.findIndex(s => s.id === action.id)
-        if (fromIndex !== -1) {
-            const segment = variation.segments[fromIndex]
-            let segments: (Segment | null)[] = JSON.parse(JSON.stringify(variation.segments))
+        return produce(variation, draft => {
+            const fromIndex = draft.segments.findIndex(s => s.id === action.id)
+            if (fromIndex === -1) return
 
-            segments[fromIndex] = null
-            segments.splice(action.toIndex, 0, segment)
-            segments = segments.filter(s => s !== null)
+            const segment = draft.segments[fromIndex]
+            draft.segments[fromIndex] = null as any
+            draft.segments.splice(action.toIndex, 0, segment)
 
-            // If EndLoop > StartLoop, swap them
-            for (let i = 0; i < segments.length; i++) {
-                const endLoop = segments[i]
-                if (endLoop?.type === "EndLoop") {
-                    for (let j = i + 1; j < segments.length; j++) {
-                        const startLoop = segments[j]
-                        if (startLoop?.type === "StartLoop" && startLoop.label_index === endLoop.label_index) {
-                            const temp = segments[i]
-                            segments[i] = segments[j]
-                            segments[j] = temp
-                            break
-                        }
-                    }
-                }
-            }
-
-            // If StartLoop and EndLoop are next to each other, remove them
-            for (let i = 0; i < segments.length - 1; i++) {
-                const a = segments[i]
-                const b = segments[i + 1]
-                if (a?.type === "StartLoop" &&
-                    b?.type === "EndLoop" &&
-                    a.label_index === b.label_index
-                ) {
-                    segments[i] = null
-                    segments[i + 1] = null
-                }
-            }
-
-            return {
-                ...variation,
-                segments: segments.filter(s => s !== null) as Segment[],
-            }
-        } else {
-            return variation
-        }
+            draft.segments = cleanLoops(draft.segments)
+        })
     case "add_segment":
         const newSeg: Segment = {
             type: "Subseg",
@@ -94,33 +92,49 @@ export function variationReducer(variation: Variation, action: VariationAction):
                 newSeg,
             ],
         }
-    case "add_loop_start": {
+    case "toggle_segment_loop": {
+        return produce(variation, draft => {
+            const i = draft.segments.findIndex(s => s.id === action.id)
+            if (i === -1) return
 
-        const startLoopSeg: Segment = {
-            id: action.id,
-            type: "StartLoop",
-            label_index: variation.segments.length ?? 0,
-        }
-        const loopSubSeg: Segment = {
-            type: "Subseg",
-            id: action.id + 1,
-            trackList: variation.segments.length + 1,
-        }
-        const endLoopSeg: Segment = {
-            type: "EndLoop",
-            id: action.id + 2,
-            label_index: variation.segments.length + 2,
-            iter_count: action.iterCount,
-        }
-        return {
-            ...variation,
-            segments: [
-                ...variation.segments,
-                startLoopSeg,
-                loopSubSeg,
-                endLoopSeg,
-            ],
-        }
+            let inLoop = false
+            let loopStartIndex = -1
+            let loopEndIndex = -1
+
+            // Traverse backwards to find StartLoops
+            for (let j = i - 1; j >= 0; j--) {
+                const s = draft.segments[j]
+                if (s.type === "StartLoop" && s.label_index !== undefined) {
+                    const startIndex = s.label_index
+                    // Now, search for matching EndLoop after the StartLoop
+                    for (let k = i + 1; k < draft.segments.length; k++) {
+                        const segment = draft.segments[k]
+                        if (segment.type === "EndLoop" && segment.label_index === startIndex) {
+                            inLoop = true
+                            loopStartIndex = j
+                            loopEndIndex = k
+                            break
+                        }
+                    }
+                    if (inLoop) break
+                }
+            }
+
+            const nextId = Math.max(...draft.segments.map(s => s.id)) + 1
+            const nextLabel = Math.max(0, ...draft.segments.map(s => ((s.type === "StartLoop" || s.type === "EndLoop") ? s.label_index ?? 0 : 0))) + 1
+
+            if (inLoop) {
+                // Remove the loop start/end
+                draft.segments.splice(loopStartIndex, 1)
+                draft.segments.splice(loopEndIndex - 1, 1)
+            } else {
+                // Create a new loop around this segment
+                draft.segments.splice(i, 0, { type: "StartLoop", id: nextId, label_index: nextLabel })
+                draft.segments.splice(i + 2, 0, { type: "EndLoop", id: nextId + 1, label_index: nextLabel, iter_count: 0 })
+            }
+
+            draft.segments = cleanLoops(draft.segments)
+        })
     }
     }
 }

--- a/mamar-web/src/app/store/variation.ts
+++ b/mamar-web/src/app/store/variation.ts
@@ -35,7 +35,7 @@ function cleanLoops(segments: (Segment | null)[]): Segment[] {
                 cleaned[i + 1] = null
             }
         }
-    }).filter(s => s !== null)
+    }).filter(s => s !== null) as Segment[]
 }
 
 export type VariationAction = {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "preinstall": "cd mamar-wasm-bridge && wasm-pack build -t web && cd ../pm64-typegen && cargo run",
-    "lint": "cargo +nightly fmt --all --check && cd mamar-web && yarn run lint"
+    "lint": "cargo fmt --all --check && cd mamar-web && yarn run lint"
   },
   "multipleStaticFileCopier": [
     {

--- a/pm64/src/bgm/cmd.rs
+++ b/pm64/src/bgm/cmd.rs
@@ -254,7 +254,7 @@ impl CommandSeq {
                 ..
             } = command
             {
-                time += *delta_time as usize;
+                time += *delta_time;
             }
         }
 
@@ -267,7 +267,7 @@ impl CommandSeq {
     /// Equivalent to [CommandSeq::len_time] for a sequence with no [Command::Note]s.
     pub fn playback_time(&self) -> usize {
         self.iter_time().last().map_or(0, |(time, event)| match event.command {
-            Command::Delay { value: delta } => time + delta as usize,
+            Command::Delay { value: delta } => time + delta,
             Command::Note { length, .. } => time + length as usize,
             _ => time,
         })
@@ -438,7 +438,7 @@ impl CommandSeq {
                 let time_at_index = current_time;
 
                 // Advance past this Delay.
-                current_time += *delta_time as usize;
+                current_time += *delta_time;
 
                 if current_time == time {
                     // This Delay introduced the time we want! :)
@@ -800,7 +800,7 @@ impl<'a> Iterator for TimeIter<'a> {
                     ..
                 } = command
                 {
-                    self.current_time += *delta_time as usize;
+                    self.current_time += *delta_time;
                 }
 
                 Some(ret)

--- a/pm64/src/bgm/midi.rs
+++ b/pm64/src/bgm/midi.rs
@@ -177,21 +177,10 @@ pub fn to_bgm(raw: &[u8]) -> Result<Bgm, Box<dyn Error>> {
     let track_list_id = bgm.add_track_list(track_list);
 
     let (_, variation) = bgm.add_variation().unwrap();
-    variation.segments = vec![
-        Segment::StartLoop {
-            id: gen_id(),
-            label_index: 0,
-        },
-        Segment::Subseg {
-            id: gen_id(),
-            track_list: track_list_id,
-        },
-        Segment::EndLoop {
-            id: gen_id(),
-            label_index: 0,
-            iter_count: 0,
-        },
-    ];
+    variation.segments = vec![Segment::Subseg {
+        id: gen_id(),
+        track_list: track_list_id,
+    }];
 
     Ok(bgm)
 }

--- a/pm64/src/bgm/midi.rs
+++ b/pm64/src/bgm/midi.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::io::prelude::*;
 use std::io::SeekFrom;
-use std::num::NonZeroU8;
 
 use midly::{MetaMessage, Smf};
 
@@ -62,7 +61,7 @@ pub fn to_bgm(raw: &[u8]) -> Result<Bgm, Box<dyn Error>> {
         pos: None,
         tracks: [
             midi_track_to_bgm_track(
-                smf.tracks.get(0),
+                smf.tracks.first(),
                 total_song_length,
                 0,
                 time_divisor,
@@ -427,7 +426,7 @@ fn midi_track_to_bgm_track(
                                                 Command::Note {
                                                     pitch: key + 104,
                                                     velocity: start.vel,
-                                                    length: convert_time(length as usize, time_divisor) as u16,
+                                                    length: convert_time(length, time_divisor) as u16,
                                                 },
                                             );
                                         }

--- a/pm64/src/rw.rs
+++ b/pm64/src/rw.rs
@@ -7,7 +7,7 @@ pub trait SeekExt: Seek {
 
 impl<S: Seek> SeekExt for S {
     fn pos(&mut self) -> Result<u64> {
-        self.seek(SeekFrom::Current(0))
+        self.stream_position()
     }
 }
 
@@ -85,6 +85,7 @@ pub trait WriteExt: Write + Seek {
     fn write_u16_be(&mut self, value: u16) -> Result<()>;
     fn write_i16_be(&mut self, value: i16) -> Result<()>;
     fn write_u32_be(&mut self, value: u32) -> Result<()>;
+    #[allow(unused)]
     fn write_cstring_lossy(&mut self, string: &str, max_len: usize) -> Result<()>; // len includes null terminator
 
     /// Seeks to a position, writes the value, then seeks back.


### PR DESCRIPTION
- Adds a ruler at the top of the editor that measures time in beats and bars (assuming 4/4 for now)
- Segment widths are now accurate to their length in time
- Loop start/end points can be moved by dragging (to existing segment boundaries)
- Loops can be created by double-clicking the loop gutter (above the ruler)
- Non-infinite loops display the number of times they will be played (iter_count+1)
- Click a loop to open a small editing dialog

<img width="578" alt="image" src="https://github.com/user-attachments/assets/a598beda-2608-4783-8c9e-5953d0447339" />
<img width="425" alt="image" src="https://github.com/user-attachments/assets/5fa24146-db10-4106-97f0-ae2a00ce7671" />
<img width="264" alt="image" src="https://github.com/user-attachments/assets/80abdbae-a650-4723-94dc-9a556aff1509" />

Fixes https://github.com/bates64/mamar/issues/13


